### PR TITLE
Logical combinations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,7 @@
 hs_err_pid*
 
 # End of https://www.gitignore.io/api/java
-
 target/
+
+#test artifacts
+db

--- a/src/main/java/com/gliwka/hyperscan/wrapper/ExpressionFlag.java
+++ b/src/main/java/com/gliwka/hyperscan/wrapper/ExpressionFlag.java
@@ -6,6 +6,12 @@ package com.gliwka.hyperscan.wrapper;
 public enum ExpressionFlag implements BitFlag {
 
     /**
+     * Expression will be compiled with no flags.
+     */
+    NO_FLAG(0),
+
+
+    /**
      * Matching will be performed case-insensitively.
      */
     CASELESS(1),
@@ -52,12 +58,12 @@ public enum ExpressionFlag implements BitFlag {
     SOM_LEFTMOST(256),
 
     /**
-     * Parse this expression as logical combination syntax.
+     * Parse the expression in logical combination syntax.
      */
     COMBINATION(512),
 
     /**
-     * Ignore match reporting for this expression.
+     * Ignore match reporting for this expression. Used for the sub-expressions in logical combinations.
      */
     QUIET(1024);
 

--- a/src/main/java/com/gliwka/hyperscan/wrapper/ExpressionFlag.java
+++ b/src/main/java/com/gliwka/hyperscan/wrapper/ExpressionFlag.java
@@ -49,7 +49,17 @@ public enum ExpressionFlag implements BitFlag {
     /**
      * Report the leftmost start of match offset when a match is found.
      */
-    SOM_LEFTMOST(256);
+    SOM_LEFTMOST(256),
+
+    /**
+     * Parse this expression as logical combination syntax.
+     */
+    COMBINATION(512),
+
+    /**
+     * Ignore match reporting for this expression.
+     */
+    QUIET(1024);
 
     private final int bits;
 

--- a/src/test/java/com/gliwka/hyperscan/wrapper/EndToEndTest.java
+++ b/src/test/java/com/gliwka/hyperscan/wrapper/EndToEndTest.java
@@ -206,14 +206,14 @@ class EndToEndTest {
     @TestWithDatabaseRoundtrip
     void logicalCombination(SerializeDatabase serialize) {
         List<String> expressionStrings = Arrays.asList(
-                "abc", //201 0
-                "def", //202 1
-                "foobar.*gh", //203 2
-                "teakettle{4,10}",  //204 3
-                "ijkl[mMn]", //205  4
-                "(0 & 1 & 2) | (3 & !4)", //1001  5
-                "(0 | 1 & 2) & (!3 | 4)", // 1002 6
-                "((0 | 1) & 2) & (3 | 4)");// 1003 7
+                "abc",
+                "def",
+                "foobar.*gh",
+                "teakettle{4,10}",
+                "ijkl[mMn]",
+                "(0 & 1 & 2) | (3 & !4)",
+                "(0 | 1 & 2) & (!3 | 4)",
+                "((0 | 1) & 2) & (3 | 4)");
         List<EnumSet<ExpressionFlag>> flags = Arrays.asList(
                 EnumSet.of(ExpressionFlag.QUIET),
                 EnumSet.of(ExpressionFlag.QUIET),


### PR DESCRIPTION
Added support for logical combination flags. PR includes a unit test ported from hyperscan library: https://github.com/intel/hyperscan/blob/master/unit/hyperscan/logical_combination.cpp#L480 