### PR TITLE
Handling for empty string matches

### DIFF
--- a/src/main/java/com/gliwka/hyperscan/wrapper/Scanner.java
+++ b/src/main/java/com/gliwka/hyperscan/wrapper/Scanner.java
@@ -119,7 +119,11 @@ public class Scanner implements Closeable {
                 match = input.substring(startIndex, endIndex + 1);
             }
 
-            matches.add(new Match(byteToIndex[(int)from], byteToIndex[(int)to - 1], match, matchingExpression));
+            if (byteToIndex.length>0) {
+                matches.add(new Match(byteToIndex[(int) from], byteToIndex[(int) to - 1], match, matchingExpression));
+            } else {
+                matches.add(new Match(0, 0, match, matchingExpression));
+            }
         });
 
         return matches;

--- a/src/main/java/com/gliwka/hyperscan/wrapper/Scanner.java
+++ b/src/main/java/com/gliwka/hyperscan/wrapper/Scanner.java
@@ -119,7 +119,7 @@ public class Scanner implements Closeable {
                 match = input.substring(startIndex, endIndex + 1);
             }
 
-            if (byteToIndex.length>0) {
+            if (byteToIndex.length > 0) {
                 matches.add(new Match(byteToIndex[(int) from], byteToIndex[(int) to - 1], match, matchingExpression));
             } else {
                 matches.add(new Match(0, 0, match, matchingExpression));

--- a/src/test/java/com/gliwka/hyperscan/wrapper/EndToEndTest.java
+++ b/src/test/java/com/gliwka/hyperscan/wrapper/EndToEndTest.java
@@ -114,6 +114,38 @@ class EndToEndTest {
     }
 
     @Test
+    void emptyStringMatch() {
+        try {
+
+            Database db = Database.compile(new Expression(".*", EnumSet.of(ExpressionFlag.ALLOWEMPTY)));
+            Scanner scanner = new Scanner();
+            scanner.allocScratch(db);
+            final List<Match> matcher = scanner.scan(db,"");
+            assertTrue(matcher.size() > 0);
+            assertEquals("", matcher.get(0).getMatchedString());
+
+        }
+        catch(Exception t) {
+            fail(t);
+        }
+    }
+
+    @Test
+    void emptyStringNoMatch() {
+        try {
+
+            Database db = Database.compile(new Expression(".+", EnumSet.of(ExpressionFlag.ALLOWEMPTY)));
+            Scanner scanner = new Scanner();
+            scanner.allocScratch(db);
+            final List<Match> matcher = scanner.scan(db,"");
+            assertTrue(matcher.isEmpty());
+
+        }
+        catch(Exception t) {
+            fail(t);
+        }
+    }
+    @Test
     void readmeExample() {
         //we define a list containing all of our expressions
         LinkedList<Expression> expressions = new LinkedList<Expression>();


### PR DESCRIPTION
The current implementation breaks when an empty string is scanned and reported as a match. 