### PR TITLE
Fix Sigsev on validation free info

### DIFF
--- a/src/main/java/com/gliwka/hyperscan/jna/HyperscanLibraryDirect.java
+++ b/src/main/java/com/gliwka/hyperscan/jna/HyperscanLibraryDirect.java
@@ -8,8 +8,6 @@ public class HyperscanLibraryDirect {
 
     public static native int hs_scan(Pointer database, String data, int length, int flags, Pointer scratch, HyperscanLibrary.match_event_handler callback, Pointer context);
 
-    public static native int hs_scan(Pointer database, Pointer data, int length, int flags, Pointer scratch, Pointer callback, Pointer context);
-
     static {
         HashMap<String,Object> opts = new HashMap<>();
         opts.put(Library.OPTION_STRING_ENCODING, "UTF-8");

--- a/src/main/java/com/gliwka/hyperscan/jna/HyperscanLibraryDirect.java
+++ b/src/main/java/com/gliwka/hyperscan/jna/HyperscanLibraryDirect.java
@@ -8,6 +8,8 @@ public class HyperscanLibraryDirect {
 
     public static native int hs_scan(Pointer database, String data, int length, int flags, Pointer scratch, HyperscanLibrary.match_event_handler callback, Pointer context);
 
+    public static native int hs_scan(Pointer database, Pointer data, int length, int flags, Pointer scratch, Pointer callback, Pointer context);
+
     static {
         HashMap<String,Object> opts = new HashMap<>();
         opts.put(Library.OPTION_STRING_ENCODING, "UTF-8");

--- a/src/main/java/com/gliwka/hyperscan/wrapper/Expression.java
+++ b/src/main/java/com/gliwka/hyperscan/wrapper/Expression.java
@@ -164,7 +164,7 @@ public class Expression {
             HyperscanLibrary.INSTANCE.hs_free_compile_error(errorStruct);
         }
         else {
-            Native.free(Pointer.nativeValue(info.getPointer()));
+            Native.free(Pointer.nativeValue(info.getValue()));
         }
 
         return new ValidationResult(errorMessage, isValid);


### PR DESCRIPTION
Expression.validate freed the wrong memory address, eventually crashing the vm