### PR TITLE
Compile on centos 6 instead of centos 7

### DIFF
--- a/travis-build/build-linux-x86_64.sh
+++ b/travis-build/build-linux-x86_64.sh
@@ -5,7 +5,7 @@ set -eu
 set -o pipefail
 
 echo Compiling inside docker
-docker run -v $TRAVIS_BUILD_DIR/travis-build:/scripts -v $(pwd)/hyperscan:/tmp/hyperscan -it centos:centos7 /bin/bash -ci /scripts/docker-script.sh
+docker run -v $TRAVIS_BUILD_DIR/travis-build:/scripts -v $(pwd)/hyperscan:/tmp/hyperscan -it centos:centos6 /bin/bash -ci /scripts/docker-script.sh
 
 cd hyperscan/build
 echo Replacing library in git repository

--- a/travis-build/docker-script.sh
+++ b/travis-build/docker-script.sh
@@ -6,8 +6,8 @@ set -o pipefail
 
 THREADS=$(nproc --all)
 
-echo Installing wget, gcc, g++, tar, make
-yum -y install wget gcc gcc-c++ tar, make
+echo Installing wget, gcc, g++, tar, make, yum-utils
+yum -y install wget gcc gcc-c++ tar make yum-utils
 
 echo Compiling and installing ragel
 cd /tmp


### PR DESCRIPTION
Hi there, we'd like to be able to use hyperscan on centos 6 machines that only have GLIBC 2.12.  The libhs.so binary in v1.0.0 requires GLIBC 2.14 - but the hyperscan documentation seems to suggest that hyperscan itself doesn't impose that requirement. These changes seem to make everything work for me on centos 6!