### PR TITLE
Make constructor for Match protected

### DIFF
--- a/src/main/java/com/gliwka/hyperscan/wrapper/Match.java
+++ b/src/main/java/com/gliwka/hyperscan/wrapper/Match.java
@@ -9,7 +9,7 @@ public class Match {
     private String matchedString;
     private Expression matchedExpression;
 
-    Match(long start, long end, String match, Expression expression) {
+    protected Match(long start, long end, String match, Expression expression) {
         startPosition = start;
         endPosition = end;
         matchedString = match;


### PR DESCRIPTION
While trying to search for patterns like an email address, we've found it's a lot faster to start the expression with a @-sign, looking up the 'user'-like prefix after the fact. In doing so, that lookup either drops the `Match` object before further processing, or rewrites it to include the prefix. The rewrite is rather contrived, as we can't instantiate a new `Match` object. Marking the constructor for this as `protected` would allow us to create a subclass (something like `RewrittenMatch`) without having to re-implement the `Match` in an extension type. Making the constructor `public` would work too (removing the need for an extension type altogether), not sure if that'd be something you're comfortable with.