### PR TITLE
Fix a race condition in Scanner (closes #158)

### DIFF
--- a/src/main/java/com/gliwka/hyperscan/wrapper/Scanner.java
+++ b/src/main/java/com/gliwka/hyperscan/wrapper/Scanner.java
@@ -37,9 +37,11 @@ public class Scanner implements Closeable {
         // the right scanner. I've decided against it to keep this implementation simple and to not have
         // to manage references between context pointers and scanner instances
 
-        if(count.incrementAndGet() >= 256) {
+        if(count.get() >= 256) {
             throw new RuntimeException("There can only be 256 non-closed Scanner instances. Create them once per thread!");
         }
+
+        count.incrementAndGet();
     }
 
 

--- a/src/main/java/com/gliwka/hyperscan/wrapper/Scanner.java
+++ b/src/main/java/com/gliwka/hyperscan/wrapper/Scanner.java
@@ -13,6 +13,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import static com.gliwka.hyperscan.jni.hyperscan.*;
@@ -26,7 +27,7 @@ import static java.util.Collections.emptyList;
  * There can only be 256 non-closed scanner instances.
  */
 public class Scanner implements Closeable {
-    private static int count = 0;
+    private static final AtomicInteger count = new AtomicInteger();
 
     public Scanner() {
         // The function pointer for the callback match_event_handler allocates native resources.
@@ -36,11 +37,9 @@ public class Scanner implements Closeable {
         // the right scanner. I've decided against it to keep this implementation simple and to not have
         // to manage references between context pointers and scanner instances
 
-        if(count >= 256) {
+        if(count.incrementAndGet() >= 256) {
             throw new RuntimeException("There can only be 256 non-closed Scanner instances. Create them once per thread!");
         }
-
-        count++;
     }
 
 
@@ -182,7 +181,7 @@ public class Scanner implements Closeable {
     public void close() {
         scratch.close();
         matchHandler.close();
-        count--;
+        count.decrementAndGet();
         scratch = null;
     }
 }


### PR DESCRIPTION
Use `AtomicInteger` to keep the count the number of `Scanner` instances.