### PR TITLE
Bugfix for one scanner with multiple DBs (exception)

### DIFF
--- a/src/main/java/com/gliwka/hyperscan/wrapper/Scanner.java
+++ b/src/main/java/com/gliwka/hyperscan/wrapper/Scanner.java
@@ -47,8 +47,10 @@ public class Scanner implements Closeable {
 
     private static class NativeScratch extends hs_scratch_t {
         void registerDeallocator() {
-            hs_scratch_t p = new hs_scratch_t(this);
-            deallocator(() -> hs_free_scratch(p));
+            if (deallocator() != null) {
+                hs_scratch_t p = new hs_scratch_t(this);
+                deallocator(() -> hs_free_scratch(p));
+            }
         }
     }
 

--- a/src/test/java/com/gliwka/hyperscan/wrapper/ScannerTest.java
+++ b/src/test/java/com/gliwka/hyperscan/wrapper/ScannerTest.java
@@ -1,0 +1,27 @@
+package com.gliwka.hyperscan.wrapper;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class ScannerTest {
+
+    @Test
+    void oneScannerWithMultipleDatabases() throws Exception {
+        try (
+                Database dbA = Database.compile(new Expression("a"));
+                Database dbB = Database.compile(new Expression("b"));
+                Scanner scanner = new Scanner()
+        ) {
+            scanner.allocScratch(dbA);
+            List<Match> matchesA = scanner.scan(dbA, "a");
+            assertFalse(matchesA.isEmpty());
+
+            scanner.allocScratch(dbB);
+            List<Match>  matchesB = scanner.scan(dbB, "b");
+            assertFalse(matchesB.isEmpty());
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/gliwka/hyperscan-java/issues/220 - Hyperscan java wrapper throws an exception when one scratch space is used with multiple databases. 
It was introduced by https://github.com/gliwka/hyperscan-java/issues/161